### PR TITLE
feat: add 'import/no-extraneous-dependencies' rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -107,6 +107,7 @@ module.exports = {
         'require-yield': WARNING, // eslint:recommended
 
         'import/no-duplicates': [ERROR, {considerQueryString: true}],
+        'import/no-extraneous-dependencies': [ERROR, {includeTypes: true}],
     },
     overrides: [
         {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable import/order */
 
 // eslint-disable-next-line import/no-duplicates
 import {test} from './file';
@@ -7,5 +8,11 @@ import {test2} from './file';
 import type {test4 as Test4} from './file';
 // eslint-disable-next-line import/no-duplicates
 import {test3} from './file.js';
+
 import {test4} from './file.js?mod2';
 import {test5} from './file?mod';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {parse} from 'json5';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type {stringify} from 'json5';


### PR DESCRIPTION
This PR adds the [rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) that makes sure that no transitive dependencies are imported in the code without explicitly specifying them in `package.json`.