### PR TITLE
feat: add consistent-type-imports rule

### DIFF
--- a/import-order.js
+++ b/import-order.js
@@ -44,5 +44,13 @@ module.exports = {
                 warnOnUnassignedImports: true,
             },
         ],
+        '@typescript-eslint/consistent-type-imports': [
+            'error',
+            {
+                fixStyle: 'inline-type-imports',
+                disallowTypeAnnotations: false,
+            },
+        ],
+        '@typescript-eslint/no-import-type-side-effects': 'error',
     },
 };

--- a/import-order.js
+++ b/import-order.js
@@ -51,6 +51,7 @@ module.exports = {
                 disallowTypeAnnotations: false,
             },
         ],
+        // To avoid imports split from `@typescript-eslint/consistent-type-imports` auto-fix
         '@typescript-eslint/no-import-type-side-effects': 'error',
     },
 };


### PR DESCRIPTION
The rule `@typescript-eslint/consistent-type-imports` enforces consistent imports of TypeScript types. It is set to 'error', meaning that it will report any violations as an error.

The `fixStyle` option is set to `inline-type-imports`, which means that the rule will try to automatically fix any incorrect type imports by converting them to inline imports. For example, it will convert an import statement like
```ts
import { SomeType, someUtil } from 'some-module';
```
to
```ts
import { type SomeType, someUtil } from 'some-module';
```

The `disallowTypeAnnotations` option is set to `false`, which means that type annotations are allowed in import statements. Type annotations are additional information provided for the TypeScript compiler to understand the shape of imported values.


The rule `@typescript-eslint/no-import-type-side-effects` is set to 'error'. It reports an error if an import statement has side effects other than side effects related to types. In other words, it flag imports that are not solely for importing types and can potentially cause unintended behavior or side effects in the code.


Both rules work together. 'consistent-type-imports' ensures consistent imports of types, while 'no-import-type-side-effects' prevents using type imports for performing actions with side effects. This allows maintaining standards, facilitates code readability and maintainability, and enhances the safety of TypeScript development.
