### PR TITLE
feat(typescript): migrate stylistic plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/eslint-parser": "^7.27.0",
         "@babel/preset-react": "^7.26.3",
         "@eslint/js": "^9.23.0",
-        "@stylistic/eslint-plugin-ts": "^4.2.0",
+        "@stylistic/eslint-plugin": "^4.2.0",
         "@typescript-eslint/eslint-plugin": "^8.30.1",
         "@typescript-eslint/parser": "^8.30.1",
         "eslint-config-prettier": "^10.1.2",
@@ -1153,14 +1153,17 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "license": "MIT"
     },
-    "node_modules/@stylistic/eslint-plugin-ts": {
+    "node_modules/@stylistic/eslint-plugin": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-4.2.0.tgz",
-      "integrity": "sha512-j2o2GvOx9v66x8hmp/HJ+0T+nOppiO5ycGsCkifh7JPGgjxEhpkGmIGx3RWsoxpWbad3VCX8e8/T8n3+7ze1Zg==",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.2.0.tgz",
+      "integrity": "sha512-8hXezgz7jexGHdo5WN6JBEIPHCSFyyU4vgbxevu4YLVS5vl+sxqAAGyXSzfNDyR6xMNSH5H1x67nsXcYMOHtZA==",
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.23.0",
         "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
+        "espree": "^10.3.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1169,15 +1172,28 @@
         "eslint": ">=9.0.0"
       }
     },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/eslint-parser": "^7.27.0",
     "@babel/preset-react": "^7.26.3",
     "@eslint/js": "^9.23.0",
-    "@stylistic/eslint-plugin-ts": "^4.2.0",
+    "@stylistic/eslint-plugin": "^4.2.0",
     "@typescript-eslint/eslint-plugin": "^8.30.1",
     "@typescript-eslint/parser": "^8.30.1",
     "eslint-config-prettier": "^10.1.2",

--- a/typescript.js
+++ b/typescript.js
@@ -1,4 +1,4 @@
-import stylisticTsPlugin from '@stylistic/eslint-plugin-ts';
+import stylisticPlugin from '@stylistic/eslint-plugin';
 import typescriptPlugin from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
 import importPlugin from 'eslint-plugin-import';
@@ -14,7 +14,7 @@ export default [
         },
         plugins: {
             '@typescript-eslint': typescriptPlugin,
-            '@stylistic/ts': stylisticTsPlugin,
+            stylistic: stylisticPlugin,
             import: importPlugin,
             jsdoc: jsdocPlugin,
         },
@@ -104,8 +104,8 @@ export default [
             '@typescript-eslint/prefer-namespace-keyword': ERROR,
 
             // Stylistic
-            '@stylistic/ts/member-delimiter-style': ERROR,
-            '@stylistic/ts/type-annotation-spacing': [
+            'stylistic/member-delimiter-style': ERROR,
+            'stylistic/type-annotation-spacing': [
                 ERROR,
                 {
                     before: true,


### PR DESCRIPTION
Added `@stylistic/eslint-plugin`.
Removed `@stylistic/eslint-plugin-ts`.
Fixed issues caused by upgrade to `@gravitu-ui/eslint-config@4.1.0` (see issue below).

```shell
eslint
# prints
[@stylistic/eslint-plugin-ts] This package is deprecated in favor of the unified @stylistic/eslint-plugin, please consider migrating to the main package
```

```shell
npm why @stylistic/eslint-plugin-ts                           
# prints
@stylistic/eslint-plugin-ts@4.4.1 dev
node_modules/@stylistic/eslint-plugin-ts
  @stylistic/eslint-plugin-ts@"^4.2.0" from @gravity-ui/eslint-config@4.1.0
  node_modules/@gravity-ui/eslint-config
    dev @gravity-ui/eslint-config@"^4.1.0" from the root project
```
