### PR TITLE
fix(package): add index.js to published files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "client.js",
     "constants.js",
     "import-order.js",
+    "index.js",
     "prettier.js",
     "react.js",
     "server.js",


### PR DESCRIPTION
Fixes import error:
`Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@gravity-ui/eslint-config/index.js'`